### PR TITLE
Add option to make airdashing follow your camera's direction, instead of your inputs

### DIFF
--- a/src/Lua/Character/LUA_soapfunc.lua
+++ b/src/Lua/Character/LUA_soapfunc.lua
@@ -332,7 +332,11 @@ rawset(_G,"Soap_ControlDir",function(p)
 	if (p.soaptable and p.soaptable.in2D)
 		return (p.cmd.sidemove < 0) and ANGLE_180 or 0
 	end
-	return (p.cmd.angleturn << 16) + R_PointToAngle2(0, 0, p.cmd.forwardmove << 16, -p.cmd.sidemove << 16)
+	if (p.soaptable and p.soaptable.airdashcamera) then
+		return p.mo.angle
+	else
+		return (p.cmd.angleturn << 16) + R_PointToAngle2(0, 0, p.cmd.forwardmove << 16, -p.cmd.sidemove << 16)
+	end
 end)
 
 --tatsuru

--- a/src/Lua/Character/LUA_soapfunc.lua
+++ b/src/Lua/Character/LUA_soapfunc.lua
@@ -332,7 +332,7 @@ rawset(_G,"Soap_ControlDir",function(p)
 	if (p.soaptable and p.soaptable.in2D)
 		return (p.cmd.sidemove < 0) and ANGLE_180 or 0
 	end
-	if (p.soaptable and p.soaptable.airdashcamera) then
+	if (p.soaptable and p.soaptable.airdashcamera and p.mo.skin == "soapthehedge") then
 		return p.mo.angle
 	else
 		return (p.cmd.angleturn << 16) + R_PointToAngle2(0, 0, p.cmd.forwardmove << 16, -p.cmd.sidemove << 16)

--- a/src/Lua/LUA_console.lua
+++ b/src/Lua/LUA_console.lua
@@ -15,6 +15,28 @@ CV.quake_mul = CV_RegisterVar({
 	PossibleValue = {Off = 0, Half = 1, Normal = 2, Double = 3},
 })
 
+-- i know this is probably ugly as fuck, but i dont actually know how to make this work with cvars without Synch problems?
+local function airdashCMD(p,arg)
+	if not arg then
+		local stat = (p.soaptable and p.soaptable.airdashcamera) and "On" or "Off"
+		CONS_Printf(p,"\"soap_airdashcamera\" is \""..stat.."\" default is \"Off\"")
+		return
+	end
+	if not p.soaptable then -- safety
+		CONS_Printf(p,"You can't use this right now.")
+		return
+	end
+	arg = $:lower()
+	if arg == "on" or arg == "1" then
+		p.soaptable.airdashcamera = true
+	elseif arg == "off" or arg == "0" then
+		p.soaptable.airdashcamera = false
+	else
+		CONS_Printf(p,"Invalid value!")
+	end
+end
+COM_AddCommand("soap_airdashcamera",airdashCMD)
+
 local CV_Lookup = {}
 setmetatable(CV_Lookup, {
 	__mode = "kv"

--- a/src/Lua/LUA_console.lua
+++ b/src/Lua/LUA_console.lua
@@ -15,14 +15,13 @@ CV.quake_mul = CV_RegisterVar({
 	PossibleValue = {Off = 0, Half = 1, Normal = 2, Double = 3},
 })
 
--- i know this is probably ugly as fuck, but i dont actually know how to make this work with cvars without Synch problems?
 local function airdashCMD(p,arg)
 	if not arg then
 		local stat = (p.soaptable and p.soaptable.airdashcamera) and "On" or "Off"
 		CONS_Printf(p,"\"soap_airdashcamera\" is \""..stat.."\" default is \"Off\"")
 		return
 	end
-	if not p.soaptable then -- safety
+	if not p.soaptable then
 		CONS_Printf(p,"You can't use this right now.")
 		return
 	end

--- a/src/Lua/LUA_init.lua
+++ b/src/Lua/LUA_init.lua
@@ -167,6 +167,7 @@ rawset(_G, "Soap_InitTable", function(p)
 		--if non-zero, delay airdash until this tics to 0
 		airdashcharge = 0,
 		noairdashforme = false,
+		airdashcamera = false,
 		
 		rdashing = false,
 		lastrdash = false,


### PR DESCRIPTION
Defaults to off, if player.soaptable.airdashcamera is true then airdashing will go in the direction the camera is facing, keeping consistent for strafe players. Adds command "soap_airdashcamera" for players to use

When (or if) LUA_clientsave.lua has support for automatically running commands with soap, I'd like this to have support with it (though for now i can live with using an alias xd)