### PR TITLE
Add Orbit YAR tumble compatibility

### DIFF
--- a/src/Lua/Character/SoapInclude/funny.lua
+++ b/src/Lua/Character/SoapInclude/funny.lua
@@ -149,7 +149,6 @@ Takis_Hook.addHook("MoveBlocked", function(me, thing,line)
 	local soap = p.soaptable
 	
 	if me.orbitbonk
-	and (Orbit and Orbit.version == "0.4.37")
 		S_StartSound(me, sfx_s3k49)
 		Soap_SpawnBumpSparks(me, thing, line)
 		if (line and line.valid)


### PR DESCRIPTION
Utilizes a totally new tumbling system from Orbit
It even should be able to tumble non-player mobjs now if support is added!
![srb28341](https://github.com/user-attachments/assets/9e694243-e19e-46f2-a197-095efd4d91f3)
![srb28344](https://github.com/user-attachments/assets/ab23c1e2-f429-4eea-a610-505dde32d001)
